### PR TITLE
Fix: User filter dropdown not showing options

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -252,10 +252,22 @@ export default function HomePage() {
       setStats(cachedDashboard.stats)
       setRecentCourses(cachedDashboard.recentCourses)
       setDashboardProgress(cachedDashboard.progress)
-      if (cachedDashboard.employees) {
+      
+      // Se há employees no cache E é admin, usar do cache e retornar
+      if (cachedDashboard.employees && cachedDashboard.employees.length > 0 && currentUser?.role === 'admin') {
+        console.log('📊 [Dashboard] Restaurando employees do cache:', cachedDashboard.employees.length)
         setEmployees(cachedDashboard.employees)
+        return
       }
-      return
+      
+      // Se não há employees no cache mas é admin, continuar para carregar employees
+      if (currentUser?.role === 'admin') {
+        console.log('📊 [Dashboard] Cache sem employees, continuando para carregar usuários')
+        // Continuar execução para carregar employees
+      } else {
+        // Se não é admin, pode retornar
+        return
+      }
     }
 
     try {
@@ -672,6 +684,10 @@ export default function HomePage() {
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Filtrar por colaborador:
                 </label>
+                {(() => {
+                  console.log('🔍 [Dashboard] Renderizando dropdown. Employees:', employees.length, employees.map(e => ({ id: e.id, name: e.name })))
+                  return null
+                })()}
                 <select
                   value={selectedEmployee?.id || ''}
                   onChange={(e) => {


### PR DESCRIPTION
- Fix cache logic to not return early when employees are missing from cache
- Add proper cache restoration logic for employees
- Add debug logs to track dropdown rendering and employee state
- Cache now properly handles both dashboard data and employees list
- Dropdown should now show all 5 users for admin selection